### PR TITLE
Allow for dynamic headers

### DIFF
--- a/src/Data/Csv/Encoding.hs
+++ b/src/Data/Csv/Encoding.hs
@@ -315,12 +315,13 @@ encodeDefaultOrderedByNameWith opts v
         toLazyByteString (rows (encIncludeHeader opts))
     | otherwise = encodeOptionsError
   where
-    hdr = (Conversion.headerOrder (undefined :: a))
+    hdr []      = Conversion.headerOrder (undefined :: a)
+    hdr (x : _) = Conversion.headerOrder x
     rows False = records
-    rows True  = encodeRecord (encQuoting opts) (encDelimiter opts) hdr <>
+    rows True  = encodeRecord (encQuoting opts) (encDelimiter opts) (hdr v) <>
                  recordSep (encUseCrLf opts) <> records
     records = unlines (recordSep (encUseCrLf opts))
-              . map (encodeNamedRecord hdr (encQuoting opts) (encDelimiter opts)
+              . map (encodeNamedRecord (hdr v) (encQuoting opts) (encDelimiter opts)
                      . toNamedRecord)
               $ v
 {-# INLINE encodeDefaultOrderedByNameWith #-}


### PR DESCRIPTION
This PR enables us to dynamically generate headers for our csv downloads.

In the process of trying to solve https://github.com/daiseeai/Concerns/issues/302 in https://github.com/daiseeai/call-backend/pull/378, we began getting errors based on an `undefined` variable. This PR replaces that undefined variable, with an example of the type, allowing us to dynamically generate headers.